### PR TITLE
Add functionality to prime GPT from the UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ demo_web_app(gpt, config)
 
 Running this code as a python script would automatically launch a web app for you to test new inputs and outputs with. There are already 3 example scripts in the `examples` directory.
 
+You can also prime GPT from the UI. for that, pass `show_example_form=True` to `UIConfig` along with other parameters.
+
 Technical details: the backend is in Flask, and the frontend is in React. Note that this repository is currently not intended for production use.
 
 ## Background

--- a/api/demo_web_app.py
+++ b/api/demo_web_app.py
@@ -31,7 +31,7 @@ def demo_web_app(gpt, config=UIConfig()):
         return Response(json.dumps({"error": err_msg}), status=status_code)
 
     def get_example(example_id):
-        """ Gets a single example or all the examples"""
+        """Gets a single example or all the examples."""
         if example_id:
             example = gpt.get_example(example_id)
             if example:
@@ -40,13 +40,13 @@ def demo_web_app(gpt, config=UIConfig()):
         return json.dumps(gpt.get_all_examples())
 
     def post_example():
-        """Adds an empty example"""
+        """Adds an empty example."""
         new_example = Example("", "")
         gpt.add_example(new_example)
         return json.dumps(gpt.get_all_examples())
 
     def put_example(args, example_id):
-        """Modifies an existing example"""
+        """Modifies an existing example."""
         if example_id:
             example = gpt.get_example(example_id)
             if example:
@@ -59,17 +59,20 @@ def demo_web_app(gpt, config=UIConfig()):
         return error("id required", HTTPStatus.BAD_REQUEST)
 
     def delete_example(example_id):
-        """Deletes an example"""
+        """Deletes an example."""
         if example_id:
             gpt.clear_example(example_id)
             return json.dumps(gpt.get_all_examples())
         return error("id required", HTTPStatus.BAD_REQUEST)
 
     @app.route(
-        "/examples", methods=["GET", "POST"], defaults={"example_id": ""},
+        "/examples",
+        methods=["GET", "POST"],
+        defaults={"example_id": ""},
     )
     @app.route(
-        "/examples/<example_id>", methods=["GET", "PUT", "DELETE"],
+        "/examples/<example_id>",
+        methods=["GET", "PUT", "DELETE"],
     )
     def examples(example_id):
         method = request.method

--- a/api/demo_web_app.py
+++ b/api/demo_web_app.py
@@ -1,9 +1,10 @@
 """Runs the web app given a GPT object and UI configuration."""
 
+import json
 import subprocess
 import openai
 
-from flask import Flask, request
+from flask import Flask, request, Response
 
 from .gpt import set_openai_key, Example
 from .ui_config import UIConfig
@@ -25,14 +26,55 @@ def demo_web_app(gpt, config=UIConfig()):
         response = config.json()
         return response
 
+    def error(err_msg, status_code):
+        return Response(json.dumps({"error": err_msg}), status=status_code)
+
+    @app.route(
+        "/examples", methods=["GET", "POST"], defaults={"example_id": ""},
+    )
+    @app.route(
+        "/examples/<example_id>", methods=["GET", "PUT", "DELETE"],
+    )
+    def examples(example_id):
+        method = request.method
+        args = request.json
+        if method == "GET":
+            # gets either a single example or all of them.
+            if example_id:
+                example = gpt.get_example(example_id)
+                if example:
+                    return json.dumps(example.as_dict())
+                return error("id not found", 404)
+            return json.dumps(gpt.get_all_examples())
+        elif method == "POST":
+            # adds an empty example.
+            new_example = Example("", "")
+            gpt.add_example(new_example)
+            return json.dumps(gpt.get_all_examples())
+        elif method == "PUT":
+            # modifies an existing example.
+            if example_id:
+                example = gpt.get_example(example_id)
+                if example:
+                    if args.get("input", None):
+                        example.input = args["input"]
+                    if args.get("output", None):
+                        example.output = args["output"]
+                    return json.dumps(example.as_dict())
+                return error("id not found", 404)
+            return error("id required", 400)
+        elif method == "DELETE":
+            # deletes an example.
+            if example_id:
+                gpt.clear_example(example_id)
+                return json.dumps(gpt.get_all_examples())
+            return error("id required", 400)
+        return error("Not implemented", 501)
+
     @app.route("/translate", methods=["GET", "POST"])
     def translate():
         # pylint: disable=unused-variable
-        req_json = request.json
-        prompt = req_json["prompt"]
-        if config.show_example_form and len(req_json["examples"]) > 0:
-            for ex in req_json["examples"]:
-                gpt.add_example(Example(ex["input"], ex["output"]))
+        prompt = request.json["prompt"]
         response = gpt.submit_request(prompt)
         return {"text": response["choices"][0]["text"][7:]}
 

--- a/api/gpt.py
+++ b/api/gpt.py
@@ -1,4 +1,5 @@
-"""Creates the Example and GPT classes for a user to interface with the OpenAI API."""
+"""Creates the Example and GPT classes for a user to interface with the OpenAI
+API."""
 
 import openai
 import uuid
@@ -11,7 +12,6 @@ def set_openai_key(key):
 
 class Example:
     """Stores an input, output pair and formats it to prime the model."""
-
     def __init__(self, inp, out):
         self.input = inp
         self.output = out
@@ -43,8 +43,9 @@ class Example:
 
 class GPT:
     """The main class for a user to interface with the OpenAI API.
-    A user can add examples and set parameters of the API request."""
 
+    A user can add examples and set parameters of the API request.
+    """
     def __init__(self, engine="davinci", temperature=0.5, max_tokens=100):
         self.examples = {}
         self.engine = engine
@@ -52,22 +53,24 @@ class GPT:
         self.max_tokens = max_tokens
 
     def add_example(self, ex):
-        """Adds an example to the object. Example must be an instance
-        of the Example class."""
+        """Adds an example to the object.
+
+        Example must be an instance of the Example class.
+        """
         assert isinstance(ex, Example), "Please create an Example object."
         self.examples[ex.get_id()] = ex
 
-    def clear_example(self, id):
-        """Clears example with the specific id"""
+    def delete_example(self, id):
+        """Delete example with the specific id."""
         if id in self.examples:
             del self.examples[id]
 
     def get_example(self, id):
-        """ Get a single example """
+        """Get a single example."""
         return self.examples.get(id, None)
 
     def get_all_examples(self):
-        """ Returns all examples as a list of dicts"""
+        """Returns all examples as a list of dicts."""
         return {k: v.as_dict() for k, v in self.examples.items()}
 
     def get_prime_text(self):

--- a/api/gpt.py
+++ b/api/gpt.py
@@ -3,12 +3,13 @@
 import openai
 import uuid
 
+
 def set_openai_key(key):
     """Sets OpenAI key."""
     openai.api_key = key
 
 
-class Example():
+class Example:
     """Stores an input, output pair and formats it to prime the model."""
 
     def __init__(self, inp, out):
@@ -29,9 +30,11 @@ class Example():
         return self.id
 
     def as_dict(self):
-        return {"input": self.get_input(),
-                "output": self.get_output(),
-                "id": self.get_id()}
+        return {
+            "input": self.get_input(),
+            "output": self.get_output(),
+            "id": self.get_id(),
+        }
 
     def format(self):
         """Formats the input, output pair."""
@@ -42,10 +45,8 @@ class GPT:
     """The main class for a user to interface with the OpenAI API.
     A user can add examples and set parameters of the API request."""
 
-    def __init__(self, engine='davinci',
-                 temperature=0.5,
-                 max_tokens=100):
-        self.examples = []
+    def __init__(self, engine="davinci", temperature=0.5, max_tokens=100):
+        self.examples = {}
         self.engine = engine
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -54,33 +55,24 @@ class GPT:
         """Adds an example to the object. Example must be an instance
         of the Example class."""
         assert isinstance(ex, Example), "Please create an Example object."
-        self.examples.append(ex)
-
-    def find_example(self, id):
-        """ Returns the index of the example with specific id"""
-        for i, example in enumerate(self.examples):
-            if example.get_id() == id:
-                return i
+        self.examples[ex.get_id()] = ex
 
     def clear_example(self, id):
         """Clears example with the specific id"""
-        index = self.find_example(id)
-        if index is not None:
-            del self.examples[index]
+        if id in self.examples:
+            del self.examples[id]
 
     def get_example(self, id):
         """ Get a single example """
-        index = self.find_example(id)
-        if index is not None:
-            return self.examples[index]
+        return self.examples.get(id, None)
 
     def get_all_examples(self):
         """ Returns all examples as a list of dicts"""
-        return [i.as_dict() for i in self.examples]
+        return {k: v.as_dict() for k, v in self.examples.items()}
 
     def get_prime_text(self):
         """Formats all examples to prime the model."""
-        return '\n'.join([i.format() for i in self.examples]) + '\n'
+        return "\n".join([i.format() for i in self.examples.values()]) + "\n"
 
     def get_engine(self):
         """Returns the engine specified for the API."""
@@ -100,17 +92,19 @@ class GPT:
 
     def submit_request(self, prompt):
         """Calls the OpenAI API with the specified parameters."""
-        response = openai.Completion.create(engine=self.get_engine(),
-                                            prompt=self.craft_query(prompt),
-                                            max_tokens=self.get_max_tokens(),
-                                            temperature=self.get_temperature(),
-                                            top_p=1,
-                                            n=1,
-                                            stream=False,
-                                            stop="\ninput:")
+        response = openai.Completion.create(
+            engine=self.get_engine(),
+            prompt=self.craft_query(prompt),
+            max_tokens=self.get_max_tokens(),
+            temperature=self.get_temperature(),
+            top_p=1,
+            n=1,
+            stream=False,
+            stop="\ninput:",
+        )
         return response
 
     def get_top_reply(self, prompt):
         """Obtains the best result as returned by the API."""
         response = self.submit_request(prompt)
-        return response['choices'][0]['text']
+        return response["choices"][0]["text"]

--- a/api/gpt.py
+++ b/api/gpt.py
@@ -1,11 +1,12 @@
 """Creates the Example and GPT classes for a user to interface with the OpenAI API."""
 
 import openai
-
+import uuid
 
 def set_openai_key(key):
     """Sets OpenAI key."""
     openai.api_key = key
+
 
 class Example():
     """Stores an input, output pair and formats it to prime the model."""
@@ -13,6 +14,7 @@ class Example():
     def __init__(self, inp, out):
         self.input = inp
         self.output = out
+        self.id = uuid.uuid4().hex
 
     def get_input(self):
         """Returns the input of the example."""
@@ -21,6 +23,15 @@ class Example():
     def get_output(self):
         """Returns the intended output of the example."""
         return self.output
+
+    def get_id(self):
+        """Returns the unique ID of the example."""
+        return self.id
+
+    def as_dict(self):
+        return {"input": self.get_input(),
+                "output": self.get_output(),
+                "id": self.get_id()}
 
     def format(self):
         """Formats the input, output pair."""
@@ -43,11 +54,33 @@ class GPT:
         """Adds an example to the object. Example must be an instance
         of the Example class."""
         assert isinstance(ex, Example), "Please create an Example object."
-        self.examples.append(ex.format())
+        self.examples.append(ex)
+
+    def find_example(self, id):
+        """ Returns the index of the example with specific id"""
+        for i, example in enumerate(self.examples):
+            if example.get_id() == id:
+                return i
+
+    def clear_example(self, id):
+        """Clears example with the specific id"""
+        index = self.find_example(id)
+        if index is not None:
+            del self.examples[index]
+
+    def get_example(self, id):
+        """ Get a single example """
+        index = self.find_example(id)
+        if index is not None:
+            return self.examples[index]
+
+    def get_all_examples(self):
+        """ Returns all examples as a list of dicts"""
+        return [i.as_dict() for i in self.examples]
 
     def get_prime_text(self):
         """Formats all examples to prime the model."""
-        return '\n'.join(self.examples) + '\n'
+        return '\n'.join([i.format() for i in self.examples]) + '\n'
 
     def get_engine(self):
         """Returns the engine specified for the API."""

--- a/api/ui_config.py
+++ b/api/ui_config.py
@@ -6,10 +6,12 @@ class UIConfig():
 
     def __init__(self, description='Description',
                  button_text='Submit',
-                 placeholder='Default placeholder'):
+                 placeholder='Default placeholder',
+                 show_example_form=False):
         self.description = description
         self.button_text = button_text
         self.placeholder = placeholder
+        self.show_example_form = show_example_form
 
     def get_description(self):
         """Returns the input of the example."""
@@ -23,8 +25,13 @@ class UIConfig():
         """Returns the intended output of the example."""
         return self.placeholder
 
+    def get_show_example_form(self):
+        """Returns whether editable example form is shown."""
+        return self.show_example_form
+
     def json(self):
         """Used to send the parameter values to the API."""
         return {"description": self.description,
                 "button_text": self.button_text,
-                "placeholder": self.placeholder}
+                "placeholder": self.placeholder,
+                "show_example_form": self.show_example_form}

--- a/examples/run_blank_example.py
+++ b/examples/run_blank_example.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 from api import GPT, Example, UIConfig
@@ -7,14 +8,17 @@ from api import demo_web_app
 
 
 # Construct GPT object and show some examples
-gpt = GPT(engine="davinci",
-          temperature=0.5,
-          max_tokens=100)
+gpt = GPT(engine="davinci", temperature=0.5, max_tokens=100)
+
+gpt.add_example(Example("Who are you?", "I'm an example."))
+gpt.add_example(Example("What are you?", "I'm an example."))
 
 # Define UI configuration
-config = UIConfig(description="Prompt",
-                  button_text="Result",
-                  placeholder="Where is Mt. Rushmore ?",
-                  show_example_form=True)
+config = UIConfig(
+    description="Prompt",
+    button_text="Result",
+    placeholder="Where are you?",
+    show_example_form=True,
+)
 
 demo_web_app(gpt, config)

--- a/examples/run_blank_example.py
+++ b/examples/run_blank_example.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from api import GPT, Example, UIConfig
+from api import demo_web_app
+
+
+# Construct GPT object and show some examples
+gpt = GPT(engine="davinci",
+          temperature=0.5,
+          max_tokens=100)
+
+# Define UI configuration
+config = UIConfig(description="Prompt",
+                  button_text="Result",
+                  placeholder="Where is Mt. Rushmore ?",
+                  show_example_form=True)
+
+demo_web_app(gpt, config)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
     "bootstrap": "^4.5.0",
+    "lodash": "^4.17.19",
     "react": "^16.13.1",
     "react-bootstrap": "^1.2.2",
     "react-dom": "^16.13.1",

--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ class App extends React.Component {
       buttonText: "Submit",
       description: "Description",
       showExampleForm: false,
-      examples: [],
+      examples: {},
     }
     // Bind the event handlers
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -52,20 +52,19 @@ class App extends React.Component {
 
  debouncedUpdateExample = debounce(this.updateExample, 50)
 
-  handleExampleChange = (index, field) => e => {
+  handleExampleChange = (id, field) => e => {
     let body = {};
     body[field]=e.target.value;
-    let id = this.state.examples[index].id;
-    let examples = [...this.state.examples];
-    examples[index][field] = e.target.value;
+    let examples = Object.assign({}, this.state.examples);
+    examples[id][field] = e.target.value;
     this.setState({ examples: examples });
     this.debouncedUpdateExample(id, body);
   }
 
- handleExampleDelete = (index) => e => {
+ handleExampleDelete = (id) => e => {
    e.preventDefault();
    axios
-     .delete(EXAMPLE_API_URL + "/" + this.state.examples[index].id)
+     .delete(EXAMPLE_API_URL + "/" + id)
      .then(({ data: examples }) => {
        this.setState({ examples: examples });
      });
@@ -89,10 +88,6 @@ class App extends React.Component {
     let body = {
       prompt: this.state.input
     };
-    if (this.state.showExampleForm) {
-      body.examples = this.state.examples
-    }
-
     axios.post(TRANSLATE_API_URL, body).then(({ data: { text } }) => {
       this.setState({ output: text });
     });
@@ -119,29 +114,29 @@ class App extends React.Component {
                 { showExampleForm &&
                 <div>
                   <Form.Label>Examples</Form.Label>
-                  { this.state.examples.map((exampleItem, index) => (
-                    <span key={index}>
-                      <Form.Group as={Row} controlId={"formExampleInput"+index}>
+                  { Object.values(this.state.examples).map((example) => (
+                    <span key={example.id}>
+                      <Form.Group as={Row} controlId={"formExampleInput" + example.id}>
                         <Form.Label column="sm" lg={2}>Example Input</Form.Label>
                         <Col sm={10}>
                           <Form.Control
                             type="text"
                             as="input"
                             placeholder="Enter text"
-                            value={this.state.examples[index].input}
-                            onChange={this.handleExampleChange(index, "input")}
+                            value={example.input}
+                            onChange={this.handleExampleChange(example.id, "input")}
                           />
                         </Col>
                       </Form.Group>
-                      <Form.Group as={Row} controlId={"formExampleOutput"+index}>
+                      <Form.Group as={Row} controlId={"formExampleOutput" + example.id}>
                         <Form.Label column="sm" lg={2}>Example Output</Form.Label>
                         <Col sm={10}>
                           <Form.Control
                             type="text"
                             as="textarea"
                             placeholder="Enter text"
-                            value={this.state.examples[index].output}
-                            onChange={this.handleExampleChange(index, "output")}
+                            value={example.output}
+                            onChange={this.handleExampleChange(example.id, "output")}
                           />
                         </Col>
                       </Form.Group>
@@ -151,7 +146,7 @@ class App extends React.Component {
                             type="button"
                             size="sm"
                             variant="danger"
-                            onClick={this.handleExampleDelete(index)}>Delete example</Button>
+                            onClick={this.handleExampleDelete(example.id)}>Delete example</Button>
                         </Col>
                       </Form.Group>
                     </span>

--- a/src/App.js
+++ b/src/App.js
@@ -18,8 +18,8 @@ class App extends React.Component {
       buttonText: "Submit",
       description: "Description",
       showExampleForm: false,
-      examples: {},
-    }
+      examples: {}
+    };
     // Bind the event handlers
     this.handleInputChange = this.handleInputChange.bind(this);
     this.handleClick = this.handleClick.bind(this);
@@ -29,55 +29,55 @@ class App extends React.Component {
     // Call API for the UI params
     axios
       .get(UI_PARAMS_API_URL)
-      .then(({ data: { placeholder, button_text, description, show_example_form } }) => {
-        this.setState({
-          input: placeholder,
-          buttonText: button_text,
-          description: description,
-          showExampleForm: show_example_form,
-        });
-        if (this.state.showExampleForm) {
-          axios
-            .get(EXAMPLE_API_URL)
-            .then(({ data: examples }) => {
-              this.setState({ examples: examples })
+      .then(
+        ({
+          data: { placeholder, button_text, description, show_example_form }
+        }) => {
+          this.setState({
+            input: placeholder,
+            buttonText: button_text,
+            description: description,
+            showExampleForm: show_example_form
+          });
+          if (this.state.showExampleForm) {
+            axios.get(EXAMPLE_API_URL).then(({ data: examples }) => {
+              this.setState({ examples });
             });
+          }
         }
-      });
+      );
   }
 
   updateExample(id, body) {
-    axios.put(EXAMPLE_API_URL + "/" + id, body)
+    axios.put(`${EXAMPLE_API_URL}/${id}`, body);
   }
 
- debouncedUpdateExample = debounce(this.updateExample, 50)
+  debouncedUpdateExample = debounce(this.updateExample, 50);
 
   handleExampleChange = (id, field) => e => {
-    let body = {};
-    body[field]=e.target.value;
-    let examples = Object.assign({}, this.state.examples);
-    examples[id][field] = e.target.value;
-    this.setState({ examples: examples });
-    this.debouncedUpdateExample(id, body);
-  }
+    const text = e.target.value;
 
- handleExampleDelete = (id) => e => {
-   e.preventDefault();
-   axios
-     .delete(EXAMPLE_API_URL + "/" + id)
-     .then(({ data: examples }) => {
-       this.setState({ examples: examples });
-     });
- }
+    let body = { field: text };
+    let examples = { ...this.state.examples };
+    examples[id][field] = text;
 
- handleExampleAdd = e => {
-   e.preventDefault();
-   axios
-     .post(EXAMPLE_API_URL)
-     .then(({ data: examples }) => {
-       this.setState({ examples: examples });
-     });
- }
+    this.setState({ examples });
+    this.debouncedUpdateExample(id, { body });
+  };
+
+  handleExampleDelete = id => e => {
+    e.preventDefault();
+    axios.delete(`${EXAMPLE_API_URL}/${id}`).then(({ data: examples }) => {
+      this.setState({ examples });
+    });
+  };
+
+  handleExampleAdd = e => {
+    e.preventDefault();
+    axios.post(EXAMPLE_API_URL).then(({ data: examples }) => {
+      this.setState({ examples });
+    });
+  };
 
   handleInputChange(e) {
     this.setState({ input: e.target.value });
@@ -94,7 +94,7 @@ class App extends React.Component {
   }
 
   render() {
-    const showExampleForm = this.state.showExampleForm
+    const showExampleForm = this.state.showExampleForm;
     return (
       <div>
         <head />
@@ -111,57 +111,78 @@ class App extends React.Component {
           >
             <Form onSubmit={this.handleClick}>
               <Form.Group controlId="formBasicEmail">
-                { showExampleForm &&
-                <div>
-                  <Form.Label>Examples</Form.Label>
-                  { Object.values(this.state.examples).map((example) => (
-                    <span key={example.id}>
-                      <Form.Group as={Row} controlId={"formExampleInput" + example.id}>
-                        <Form.Label column="sm" lg={2}>Example Input</Form.Label>
-                        <Col sm={10}>
-                          <Form.Control
-                            type="text"
-                            as="input"
-                            placeholder="Enter text"
-                            value={example.input}
-                            onChange={this.handleExampleChange(example.id, "input")}
-                          />
-                        </Col>
-                      </Form.Group>
-                      <Form.Group as={Row} controlId={"formExampleOutput" + example.id}>
-                        <Form.Label column="sm" lg={2}>Example Output</Form.Label>
-                        <Col sm={10}>
-                          <Form.Control
-                            type="text"
-                            as="textarea"
-                            placeholder="Enter text"
-                            value={example.output}
-                            onChange={this.handleExampleChange(example.id, "output")}
-                          />
-                        </Col>
-                      </Form.Group>
-                      <Form.Group as={Row}>
-                        <Col sm={{ span: 10, offset: 2 }}>
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="danger"
-                            onClick={this.handleExampleDelete(example.id)}>Delete example</Button>
-                        </Col>
-                      </Form.Group>
-                    </span>
-                  ))
-                }
-                  <Form.Group as={Row}>
-                    <Col sm={{ span: 10 }}>
-                      <Button
-                        type="button"
-                        variant="primary"
-                        onClick={this.handleExampleAdd}>Add example</Button>
-                    </Col>
-                  </Form.Group>
-                </div>
-               }
+                {showExampleForm && (
+                  <div>
+                    <Form.Label>Examples</Form.Label>
+                    {Object.values(this.state.examples).map(example => (
+                      <span key={example.id}>
+                        <Form.Group
+                          as={Row}
+                          controlId={"formExampleInput" + example.id}
+                        >
+                          <Form.Label column="sm" lg={2}>
+                            Example Input
+                          </Form.Label>
+                          <Col sm={10}>
+                            <Form.Control
+                              type="text"
+                              as="input"
+                              placeholder="Enter text"
+                              value={example.input}
+                              onChange={this.handleExampleChange(
+                                example.id,
+                                "input"
+                              )}
+                            />
+                          </Col>
+                        </Form.Group>
+                        <Form.Group
+                          as={Row}
+                          controlId={"formExampleOutput" + example.id}
+                        >
+                          <Form.Label column="sm" lg={2}>
+                            Example Output
+                          </Form.Label>
+                          <Col sm={10}>
+                            <Form.Control
+                              type="text"
+                              as="textarea"
+                              placeholder="Enter text"
+                              value={example.output}
+                              onChange={this.handleExampleChange(
+                                example.id,
+                                "output"
+                              )}
+                            />
+                          </Col>
+                        </Form.Group>
+                        <Form.Group as={Row}>
+                          <Col sm={{ span: 10, offset: 2 }}>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="danger"
+                              onClick={this.handleExampleDelete(example.id)}
+                            >
+                              Delete example
+                            </Button>
+                          </Col>
+                        </Form.Group>
+                      </span>
+                    ))}
+                    <Form.Group as={Row}>
+                      <Col sm={{ span: 10 }}>
+                        <Button
+                          type="button"
+                          variant="primary"
+                          onClick={this.handleExampleAdd}
+                        >
+                          Add example
+                        </Button>
+                      </Col>
+                    </Form.Group>
+                  </div>
+                )}
                 <Form.Label>{this.state.description}</Form.Label>
                 <Form.Control
                   type="text"

--- a/src/App.js
+++ b/src/App.js
@@ -134,14 +134,16 @@ class App extends React.Component {
                     </span>
                   ))
                 }
-                <Form.Group as={Row}>
-                  <Col sm={{ span: 10 }}>
-                    <Button
-                      type="button"
-                      variant="primary"
-                      onClick={this.handleExampleAdd}>Add example</Button>
-                  </Col>
-                </Form.Group>
+                { show_example_form &&
+                  <Form.Group as={Row}>
+                    <Col sm={{ span: 10 }}>
+                      <Button
+                        type="button"
+                        variant="primary"
+                        onClick={this.handleExampleAdd}>Add example</Button>
+                    </Col>
+                  </Form.Group>
+               }
                 <Form.Label>{this.state.description}</Form.Label>
                 <Form.Control
                   type="text"

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ class App extends React.Component {
       input: "",
       buttonText: "Submit",
       description: "Description",
-      show_example_form: false,
+      showExampleForm: false,
     };
 
     // Bind the event handlers
@@ -32,7 +32,7 @@ class App extends React.Component {
           input: placeholder,
           buttonText: button_text,
           description: description,
-          show_example_form: show_example_form,
+          showExampleForm: show_example_form,
           examples: [],
         });
       });
@@ -68,7 +68,7 @@ class App extends React.Component {
     let body = {
       prompt: this.state.input
     };
-    if (this.state.show_example_form) {
+    if (this.state.showExampleForm) {
       body.examples = this.state.examples
     }
 
@@ -78,7 +78,7 @@ class App extends React.Component {
   }
 
   render() {
-    const show_example_form = this.state.show_example_form
+    const showExampleForm = this.state.showExampleForm
     return (
       <div>
         <head />
@@ -95,8 +95,9 @@ class App extends React.Component {
           >
             <Form onSubmit={this.handleClick}>
               <Form.Group controlId="formBasicEmail">
-                { show_example_form &&
+                { showExampleForm &&
                 <div>
+                  <Form.Label>Examples</Form.Label>
                   { this.state.examples.map((exampleItem, index) => (
                     <span key={index}>
                       <Form.Group as={Row} controlId={"formExampleInput"+index}>

--- a/src/App.js
+++ b/src/App.js
@@ -113,7 +113,7 @@ class App extends React.Component {
               <Form.Group controlId="formBasicEmail">
                 {showExampleForm && (
                   <div>
-                    <Form.Label>Examples</Form.Label>
+                    <h4 style={{ marginBottom: "25px" }}>Examples</h4>
                     {Object.values(this.state.examples).map(example => (
                       <span key={example.id}>
                         <Form.Group

--- a/src/App.js
+++ b/src/App.js
@@ -96,9 +96,10 @@ class App extends React.Component {
             <Form onSubmit={this.handleClick}>
               <Form.Group controlId="formBasicEmail">
                 { show_example_form &&
-                  this.state.examples.map((exampleItem, index) => (
+                <div>
+                  { this.state.examples.map((exampleItem, index) => (
                     <span key={index}>
-                      <Form.Group as={Row} controlId="formHorizontalEmail">
+                      <Form.Group as={Row} controlId={"formExampleInput"+index}>
                         <Form.Label column="sm" lg={2}>Example Input</Form.Label>
                         <Col sm={10}>
                           <Form.Control
@@ -110,7 +111,7 @@ class App extends React.Component {
                           />
                         </Col>
                       </Form.Group>
-                      <Form.Group as={Row} controlId="formHorizontalEmail">
+                      <Form.Group as={Row} controlId={"formExampleOutput"+index}>
                         <Form.Label column="sm" lg={2}>Example Output</Form.Label>
                         <Col sm={10}>
                           <Form.Control
@@ -134,7 +135,6 @@ class App extends React.Component {
                     </span>
                   ))
                 }
-                { show_example_form &&
                   <Form.Group as={Row}>
                     <Col sm={{ span: 10 }}>
                       <Button
@@ -143,6 +143,7 @@ class App extends React.Component {
                         onClick={this.handleExampleAdd}>Add example</Button>
                     </Col>
                   </Form.Group>
+                </div>
                }
                 <Form.Label>{this.state.description}</Form.Label>
                 <Form.Control


### PR DESCRIPTION
This PR lets you prime GPT from the UI. It adds a form for adding input/output pairs. You can add/delete examples within
the UI.

This feature is disabled by default. You need to pass `show_example_form=True` to `UIConfig` along with other parameters to enable this.

![example_form](https://user-images.githubusercontent.com/62241776/88277311-24d63900-ccfe-11ea-9347-529c955c419d.png)

