### PR TITLE
Reverting to using empty string joins tokens between formatted examples ( possible merge issue? )

### DIFF
--- a/api/gpt.py
+++ b/api/gpt.py
@@ -85,8 +85,8 @@ class GPT:
 
     def get_prime_text(self):
         """Formats all examples to prime the model."""
-        return "\n".join(
-            [self.format_example(ex) for ex in self.examples.values()]) + "\n"
+        return "".join(
+            [self.format_example(ex) for ex in self.examples.values()])
 
     def get_engine(self):
         """Returns the engine specified for the API."""


### PR DESCRIPTION
In a previous merge ( https://github.com/shreyashankar/gpt3-sandbox/pull/45/files ) the newlines tokens between formatted examples were replaced with empty strings,  as the newlines or other joining tokens are now handled as part of the format_example method.

I noticed in the last merge that the newlines are now used as joining tokens again.   I'm not sure if this was intentional,  but if it was just a merge issue it is having the consequence of adding additional newlines to the prompts
