### PR TITLE
Fix typo in interactive priming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The real power of GPT-3 is in its ability to learn to specialize to tasks given 
 >>> set_openai_key(key)
 >>> prompt = "integral from a to b of f of x"
 >>> print(gpt.get_top_reply(prompt))
-output: integral from at to be of f of x
+output: integral from a to be of f of x
 
 >>> gpt.add_example(Example("Two plus two equals four", "2 + 2 = 4"))
 >>> print(gpt.get_top_reply(prompt))


### PR DESCRIPTION
I noticed in the [README.md](https://github.com/shreyashankar/gpt3-sandbox/blob/master/README.md) file that there was a very minor typo in the "interactive priming example" where the letter "a" was mistyped to "at". This PR fixes that change.

> "integral from at to b..." -> "integral from a to b..."
