### PR TITLE
fix(requirements): Change requirements for conflicting dependencies

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,4 +13,4 @@ python-dotenv==0.14.0
 requests==2.27.1
 six==1.15.0
 urllib3==1.26.5
-Werkzeug==2.2.3
+Werkzeug==2.0.3


### PR DESCRIPTION
Observed error:

```
ERROR: Cannot install -r api/requirements.txt (line 16), -r api/requirements.txt (line 8) and MarkupSafe==1.1.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested MarkupSafe==1.1.1
    jinja2 2.11.3 depends on MarkupSafe>=0.23
    werkzeug 2.2.3 depends on MarkupSafe>=2.1.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

This gets resolved by this PR.